### PR TITLE
impl function blink.indent.{enable,disable,toggle}

### DIFF
--- a/lua/blink/indent/config.lua
+++ b/lua/blink/indent/config.lua
@@ -23,6 +23,7 @@
 --- @field blocked BlockedConfig
 --- @field static StaticConfig
 --- @field scope ScopeConfig
+--- @field visible boolean
 --- @field default IndentConfig
 local config = {
   default = {
@@ -73,6 +74,7 @@ local config = {
         },
       },
     },
+    visible = true,
   },
 }
 

--- a/lua/blink/indent/init.lua
+++ b/lua/blink/indent/init.lua
@@ -21,7 +21,7 @@ M.internal_setup = function(opts)
   vim.api.nvim_set_decoration_provider(ns, {
     on_win = function(_, winnr, bufnr)
       vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
-      if utils.is_buf_blocked(bufnr) then return end
+      if not config.visible or utils.is_buf_blocked(bufnr) then return end
 
       local range = utils.get_win_scroll_range(winnr)
       if range.end_line == range.start_line then return end
@@ -120,6 +120,51 @@ M.setup_hl_groups = function()
   set_hl('Cyan', '#a89984')
   set_hl('Blue', '#458588')
   set_hl('Violet', '#b16286')
+end
+
+--- Enables the visibility of indent guides
+--- @return boolean success Returns true if state changed, false if already enabled
+M.enable = function()
+  local config = require('blink.indent.config')
+
+  if config.visible then
+    -- Already enabled
+    return false
+  end
+
+  config.visible = true
+
+  return true
+end
+
+--- Disables the visibility of indent guides
+--- @return boolean success Returns true if state changed, false if already disabled
+M.disable = function()
+  local config = require('blink.indent.config')
+
+  if not config.visible then
+    -- Already disabled
+    return false
+  end
+
+  config.visible = false
+  local ns = vim.api.nvim_create_namespace('indent')
+
+  -- Clear indent markers from all buffers
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+    end
+  end
+
+  return true
+end
+
+--- Toggles the visibility of indent guides
+--- @return boolean new_state Returns the new visibility state
+M.toggle = function()
+  local config = require('blink.indent.config')
+  return config.visible and M.disable() or M.enable()
 end
 
 return M

--- a/readmes/indent/README.md
+++ b/readmes/indent/README.md
@@ -14,6 +14,8 @@
   opts = {
     indent = {
       enabled = true,
+      -- start with indent guides visible
+      visible = true,
       blocked = {
         buftypes = {},
         filetypes = {},


### PR DESCRIPTION
Closes #3.

This provides three clear API functions:

- `blink.indent.enable`
- `blink.indent.disable`
- `blink.indent.toggle`

Each function returns a boolean indicating either the success of the operation (for `enable`/`disable`) or the new state (for `toggle`). This allows plugin users to write conditional logic based on the operation's outcome.

Summary of changes, by file:

lua/blink/indent/config.lua

- add visibility state

lua/blink/indent/init.lua

- make decoration provider respect visibility state
- clear all indent markers when disabling